### PR TITLE
add hex metadata to app.src file

### DIFF
--- a/src/rebar_prv_eqc.app.src
+++ b/src/rebar_prv_eqc.app.src
@@ -3,5 +3,9 @@
   {vsn, "0.0.3"},
   {registered, []},
   {applications, [kernel, stdlib]},
-  {env, []}
+  {env, []},
+
+  {contributors, ["Kelly McLaughlin "]},
+  {licenses, ["Apache"]},
+  {links, [{"Github", "https://github.com/kellymclaughlin/rebar3-eqc-plugin"}]}
 ]}.


### PR DESCRIPTION
I'm looking to add plugins to http://www.rebar3.org/v3.0/docs/using-available-plugins as a sort of curated list of available plugins. But I also want them to be available from hex first. This PR adds the necessary metadata for hex publishing. Would you publish it to hex (http://www.rebar3.org/v3.0/docs/hex-package-management#user) or is it ok if I do it?
