### PR TITLE
Support rebar versions without rebar_utils:reread_config/2

### DIFF
--- a/src/rebar3_eqc.erl
+++ b/src/rebar3_eqc.erl
@@ -47,7 +47,7 @@ do(State) ->
                                rebar_file_utils:consult_config(State, Filename)
                             end, SysConfigs),
     [application:load(Application) || Config <- Configs, {Application, _} <- Config],
-    rebar_utils:reread_config(Configs, [update_logger]),
+    reread_config(Configs, [update_logger]),
 
     case prepare_tests(State, EqcOpts) of
         {ok, Tests} ->
@@ -645,3 +645,12 @@ check_epmd({ok, _}) ->
 check_epmd({error, Reason}) ->
     rebar_utils:abort("Erlang Distribution failed: ~p. "
                       "Verify that epmd is running and try again.", [Reason]).
+
+reread_config(ConfigList, Opts) ->
+    _ = rebar_utils:module_info(), % make sure rebar_utils is loaded
+    case erlang:function_exported(rebar_utils, reread_config, 2) of
+        true ->
+            rebar_utils:reread_config(ConfigList, Opts);
+        false ->
+            rebar_utils:reread_config(ConfigList)
+    end.


### PR DESCRIPTION
I understand that in the future the support for old versions of rebar3 [may be dropped](https://github.com/kellymclaughlin/rebar3-eqc-plugin/pull/26#issue-225425731) though it would be useful keeping backward compatibility for some intermediary commits.

Please refer to commit message for details.