### PR TITLE
Support the status of EQC availability changing at runtime

### DIFF
--- a/src/rebar3_eqc.erl
+++ b/src/rebar3_eqc.erl
@@ -81,8 +81,6 @@ do_tests(State, EqcOpts, _Tests) ->
     {EqcFun, TestQuantity} = numtests_or_testing_time(EqcOpts),
     CounterExMode = lists:member({counterexample, true}, EqcOpts),
 
-    ok = rebar_prv_cover:maybe_write_coverdata(State, ?PROVIDER),
-
     ProjectApps = project_apps(State),
     AllPropsRaw = properties(app_modules(app_names(ProjectApps), []) ++
                                  test_modules(State,
@@ -108,6 +106,7 @@ do_tests(State, EqcOpts, _Tests) ->
         {error, Reason} ->
             ?PRV_ERROR(Reason);
         ok ->
+            ok = rebar_prv_cover:maybe_write_coverdata(State, ?PROVIDER),
             {ok, State}
     end.
 


### PR DESCRIPTION
One problem with the current plugin is that if it's compiled before EQC is available, it won't work thereafter until you manually delete it and force it to be recompiled. This can happen quite a bit if you have several Erlang installs and switch between them, but don't have EQC installed in every one.

This PR allows the plugin to recompile itself if the status of EQC changes, when EQC is not available it tells you to install it and when EQC becomes available the plugin recompiles itself to reflect that.

Additionally this PR fixes an issue with coverdata from EQC tests being written.