### PR TITLE
Attempt to inject eqc path to rebar3 erlang code compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.rebar3/
+ebin/


### PR DESCRIPTION
Lately we've been having compile failures like this

```
===> Compiling _build/test/lib/blockchain/eqc/path_v2_eqc.erl failed
_build/test/lib/blockchain/eqc/path_v2_eqc.erl:3: can't find include lib "eqc/include/eqc.hrl"; Make sure eqc is in your app file's 'applications' list
_build/test/lib/blockchain/eqc/path_v2_eqc.erl:9: undefined macro 'FORALL/3'
_build/test/lib/blockchain/eqc/path_v2_eqc.erl:82: undefined macro 'SUCHTHAT/3'
```

So this branch attempts to inject the eqc paths for the rebar3_erlc_compiler module, but... it still doesn't work.  I'm opening this PR in the off chance that someone has an idea how to fix this problem.